### PR TITLE
fix: Adding index.ts to fix importing of the color library

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @since 1.1.0
+ */
+export * from './lib/internal'

--- a/lib/internal.ts
+++ b/lib/internal.ts
@@ -1,0 +1,6 @@
+/**
+ * @since 1.1.0
+ */
+export * from "./Color";
+export * from './ColorConstants';
+export * from './ColorUtils';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
             "email": "kgilland@caci.com"
         }
     ],
+    "main": "dist/index.js",
     "homepage": "https://www.nga.mil",
     "engines": {
         "npm": ">= 8.x"


### PR DESCRIPTION
Importing of the color library requires a reference to dist, and it should not